### PR TITLE
Add replay button

### DIFF
--- a/src/routes/Match/Time/AutoplayControls.js
+++ b/src/routes/Match/Time/AutoplayControls.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import Slider from 'rc-slider'
 import 'rc-slider/assets/index.css'
@@ -6,6 +6,7 @@ import 'rc-slider/assets/index.css'
 const StyledSlider = styled(Slider)`
     padding-top: 5px;
     margin-top: 12px;
+    grid-column: 2;
     min-width: 80px;
 `
 
@@ -13,21 +14,22 @@ const ControlButton = styled.button`
     padding: 0;
     font-size: 2rem;
     border: 0;
-    margin-bottom: 0;
-    margin-left: 10px;
+    margin: 0 10px;
     width: 25px;
-
-    &:last-child {
-        margin-right: 10px;
-    }
+    grid-column: 1;
 `
 
 const ControlsWrapper = styled.div`
-    display: flex;
+    display: grid;
+
+    @media (max-width: 700px) {
+        grid-column: 3;
+    }
 `
 
 const SliderContainer = styled.div`
     position: relative;
+    grid-column: 2;
     margin-right: 10px;
 `
 
@@ -67,12 +69,9 @@ class AutoplayControls extends React.PureComponent {
             <ControlsWrapper>
                 <div>
                     {!isFinished && 
-                        <Fragment>
-                            <ControlButton className="button" type="submit" onClick={toggleAutoplay}>
-                                <i className={`fi-${autoplay ? 'pause' : 'play'}`} />
-                            </ControlButton>
-                            <RewindButton rewindToStart={rewindToStart} />
-                        </Fragment>
+                        <ControlButton className="button" type="submit" onClick={toggleAutoplay}>
+                            <i className={`fi-${autoplay ? 'pause' : 'play'}`} />
+                        </ControlButton>
                     }
                     {isFinished &&
                         <RewindButton rewindToStart={rewindToStart} />

--- a/src/routes/Match/Time/AutoplayControls.js
+++ b/src/routes/Match/Time/AutoplayControls.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import styled from 'styled-components'
 import Slider from 'rc-slider'
 import 'rc-slider/assets/index.css'
@@ -6,30 +6,28 @@ import 'rc-slider/assets/index.css'
 const StyledSlider = styled(Slider)`
     padding-top: 5px;
     margin-top: 12px;
-    grid-column: 2;
     min-width: 80px;
 `
 
-const PlayButton = styled.button`
+const ControlButton = styled.button`
     padding: 0;
     font-size: 2rem;
     border: 0;
-    margin: 0 10px;
+    margin-bottom: 0;
+    margin-left: 10px;
     width: 25px;
-    grid-column: 1;
+
+    &:last-child {
+        margin-right: 10px;
+    }
 `
 
 const ControlsWrapper = styled.div`
-    display: grid;
-
-    @media (max-width: 700px) {
-        grid-column: 3;
-    }
+    display: flex;
 `
 
 const SliderContainer = styled.div`
     position: relative;
-    grid-column: 2;
     margin-right: 10px;
 `
 
@@ -46,14 +44,40 @@ const Tooltip = styled.div.attrs({
     text-align: center;
 `
 
+const RewindButton = ({ rewindToStart }) => {
+    return (
+        <ControlButton className="button" type="submit" onClick={rewindToStart}>
+            <i className="fi-previous" />
+        </ControlButton>
+    )
+}
+
 class AutoplayControls extends React.PureComponent {
     render() {
-        const { autoplay, toggleAutoplay, changeSpeed, autoplaySpeed } = this.props
+        const { 
+            autoplay, 
+            autoplaySpeed,
+            changeSpeed,
+            isFinished,
+            toggleAutoplay,
+            rewindToStart
+        } = this.props
+
         return (
             <ControlsWrapper>
-                <PlayButton className="button" type="submit" onClick={toggleAutoplay}>
-                    <i className={`fi-${autoplay ? 'pause' : 'play'}`} />
-                </PlayButton>
+                <div>
+                    {!isFinished && 
+                        <Fragment>
+                            <ControlButton className="button" type="submit" onClick={toggleAutoplay}>
+                                <i className={`fi-${autoplay ? 'pause' : 'play'}`} />
+                            </ControlButton>
+                            <RewindButton rewindToStart={rewindToStart} />
+                        </Fragment>
+                    }
+                    {isFinished &&
+                        <RewindButton rewindToStart={rewindToStart} />
+                    }
+                </div>
                 <SliderContainer>
                     <StyledSlider
                         min={1}

--- a/src/routes/Match/Time/TimeTracker.js
+++ b/src/routes/Match/Time/TimeTracker.js
@@ -127,6 +127,14 @@ class TimeTracker extends React.Component {
         }
     }
 
+    rewindToStart = () => {
+        if (this.state.autoplay) {
+            this.stopAutoplay()
+        }
+
+        this.setState({ msSinceEpoch: 1000 })
+    }
+
     render() {
         const { telemetry } = this.props
         const renderProps = {
@@ -140,6 +148,7 @@ class TimeTracker extends React.Component {
                 toggleAutoplay: this.toggleAutoplay,
                 setAutoplaySpeed: this.setAutoplaySpeed,
                 setMsSinceEpoch: this.setMsSinceEpoch,
+                rewindToStart: this.rewindToStart
             },
         }
 

--- a/src/routes/Match/index.js
+++ b/src/routes/Match/index.js
@@ -244,6 +244,8 @@ class Match extends React.Component {
                                         autoplaySpeed={timeControls.autoplaySpeed}
                                         toggleAutoplay={timeControls.toggleAutoplay}
                                         changeSpeed={timeControls.setAutoplaySpeed}
+                                        isFinished={(match.durationSeconds + 5) === (msSinceEpoch / 1000)}
+                                        rewindToStart={timeControls.rewindToStart}
                                     />
                                 </MatchHeader>
                                 <Map


### PR DESCRIPTION
I thought it would be convenient to have a button to rewind to the start. 

Behaviour:
- Shows next to the play/pause button if the match has not yet finished
- Only shows the rewind button if the match has finished
- Rewinds to the start and toggles autoplay to off.

Add a replay button to controls
Add rewindToStart fn to TimeTracker
Add isFinished prop to check if the match is over