### PR TITLE
Local replay error handling

### DIFF
--- a/src/components/FileUploadButton.js
+++ b/src/components/FileUploadButton.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import { LOCAL_REPLAY_EXTENSION } from '../lib/match-export'
 
 const HiddenFileInput = styled.input`
     display: none;
@@ -23,6 +24,7 @@ class FileUploadButton extends React.Component {
                 </UploadButton>
                 <HiddenFileInput
                     type="file"
+                    accept={LOCAL_REPLAY_EXTENSION}
                     innerRef={ref => { this.fileInputRef = ref }}
                     onChange={this.props.onFile}
                 />

--- a/src/components/MatchPlayer/DownloadButton.js
+++ b/src/components/MatchPlayer/DownloadButton.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import MapButton from '../../components/MapButton.js'
-import { downloadJSON } from '../../lib/match-export.js'
+import { downloadJSON, LOCAL_REPLAY_VERSION } from '../../lib/match-export.js'
 
 const DownloadIcon = MapButton.extend`
     top: 63px;
@@ -14,7 +14,13 @@ const DownloadIcon = MapButton.extend`
 class DownloadButton extends React.PureComponent {
     downloadMatch = () => {
         const { match, rawTelemetry, playerName } = this.props
-        downloadJSON({ match, rawTelemetry, playerName })
+
+        downloadJSON({
+            version: LOCAL_REPLAY_VERSION,
+            match,
+            rawTelemetry,
+            playerName,
+        })
     }
 
     render() {

--- a/src/lib/match-export.js
+++ b/src/lib/match-export.js
@@ -3,6 +3,8 @@ import { friendlyMapName } from './util'
 
 export const LOCAL_REPLAY_VERSION = 1
 
+export const LOCAL_REPLAY_EXTENSION = '.pubgsh.json'
+
 const generateMatchFilename = (match, playerName = undefined) => {
     const dateFragment = moment(match.playedAt).format('YYYY-MM-DD-HH-mm')
     const modeFragment = match.gameMode
@@ -11,7 +13,9 @@ const generateMatchFilename = (match, playerName = undefined) => {
         ? `-${playerName}`
         : ''
 
-    return `pubgsh${playerNameFragment}-${dateFragment}-${modeFragment}-${mapFragment}.json`
+    const fileName = `pubgsh${playerNameFragment}-${dateFragment}-${modeFragment}-${mapFragment}`
+
+    return `${fileName}${LOCAL_REPLAY_EXTENSION}`
 }
 
 export const downloadJSON = data => {

--- a/src/lib/match-export.js
+++ b/src/lib/match-export.js
@@ -1,6 +1,8 @@
 import moment from 'moment'
 import { friendlyMapName } from './util'
 
+export const LOCAL_REPLAY_VERSION = 1
+
 const generateMatchFilename = (match, playerName = undefined) => {
     const dateFragment = moment(match.playedAt).format('YYYY-MM-DD-HH-mm')
     const modeFragment = match.gameMode

--- a/src/routes/LocalMatch/index.js
+++ b/src/routes/LocalMatch/index.js
@@ -14,45 +14,84 @@ const Message = styled.p`
     text-align: center;
 `
 
+const INITIAL_STATE = {
+    // JSON file
+    loading: true,
+    fileError: false,
+    parseError: false,
+    loadedVersion: null,
+    versionError: false,
+    rawTelemetry: null,
+
+    // Telemetry
+    telemetry: null,
+    telemetryLoaded: false,
+    telemetryError: false,
+    rosters: null,
+    globalState: null,
+}
+
 class LocalMatch extends React.Component {
-    state = {
-        loading: true,
-        error: false,
-        rawTelemetry: null,
-        telemetry: null,
-        telemetryLoaded: false,
-        telemetryError: false,
-        rosters: null,
-        globalState: null,
-    }
+    state = INITIAL_STATE
 
     // -------------------------------------------------------------------------
-    // Telemetry, Lifecycle ----------------------------------------------------
+    // Lifecycle ---------------------------------------------------------------
     // -------------------------------------------------------------------------
 
     componentDidMount() {
+        this.loadLocalReplay()
+    }
+
+    // -------------------------------------------------------------------------
+    // Match, Telemetry --------------------------------------------------------
+    // -------------------------------------------------------------------------
+
+    loadLocalReplay = () => {
         // Read replay JSON from file stored in history state
 
         const reader = new FileReader()
 
         reader.onload = read => {
-            try {
-                const data = JSON.parse(read.target.result)
+            let data
 
+            try {
+                data = JSON.parse(read.target.result)
+            } catch (error) {
+                console.error('Error parsing JSON', error)
+                this.setState({ loading: false, parseError: true })
+                return
+            }
+
+            if (!data.version) {
+                console.error('Missing version in JSON')
+                this.setState({ loading: false, parseError: true })
+                return
+            }
+
+            switch (data.version) {
+            // Replay version 1
+            case 1: {
                 if (!data.playerName || !data.match || !data.rawTelemetry) {
-                    throw new Error('Loaded invalid replay JSON')
+                    console.error('Missing field(s) in JSON')
+                    this.setState({ loading: false, parseError: true })
+                    return
                 }
 
                 this.loadTelemetry(data)
-            } catch (error) {
-                console.error(error)
-                this.setState({ loading: false, error: true })
+                return
+            }
+
+            // Unsupported version
+            default: {
+                console.error(`Unsupported replay version ${data.version}`)
+                this.setState({ loading: false, loadedVersion: data.version, versionError: true })
+            }
             }
         }
 
         reader.onerror = error => {
-            console.error('Error reading replay file', error)
-            this.setState({ loading: false, error: true })
+            console.error('Error reading replay file', error.target.error, error)
+            this.setState({ loading: false, fileError: true })
         }
 
         reader.readAsText(this.props.location.state.file)
@@ -111,7 +150,10 @@ class LocalMatch extends React.Component {
         const {
             // JSON file
             loading,
-            error,
+            fileError,
+            parseError,
+            loadedVersion,
+            versionError,
             playerName,
             match,
             rawTelemetry,
@@ -128,8 +170,16 @@ class LocalMatch extends React.Component {
 
         if (loading) {
             content = <Message>Loading...</Message>
-        } else if (error || telemetryError) {
-            content = <Message>An error occurred :(</Message>
+        } else if (fileError) {
+            content = <Message>Error loading replay file :(</Message>
+        } else if (parseError) {
+            content = <Message>
+                Invalid replay file. Only replays downloaded from pubg.sh are supported.
+            </Message>
+        } else if (versionError) {
+            content = <Message>Unsupported replay version ${loadedVersion} :(</Message>
+        } else if (telemetryError) {
+            content = <Message>Error loading telemetry :(</Message>
         } else if (!telemetryLoaded) {
             content = <Message>Loading telemetry...</Message>
         } else {

--- a/src/routes/LocalMatch/index.js
+++ b/src/routes/LocalMatch/index.js
@@ -17,6 +17,7 @@ const Message = styled.p`
 const INITIAL_STATE = {
     // JSON file
     loading: true,
+    missingFileError: false,
     fileError: false,
     parseError: false,
     loadedVersion: null,
@@ -60,6 +61,15 @@ class LocalMatch extends React.Component {
     // -------------------------------------------------------------------------
 
     loadLocalReplay = () => {
+        if (!this.props.location.state ||
+            !this.props.location.state.file ||
+            !(this.props.location.state.file instanceof File)
+        ) {
+            console.error('No file in history state')
+            this.setState({ loading: false, missingFileError: true })
+            return
+        }
+
         // Read replay JSON from file stored in history state
 
         const reader = new FileReader()
@@ -163,6 +173,7 @@ class LocalMatch extends React.Component {
         const {
             // JSON file
             loading,
+            missingFileError,
             fileError,
             parseError,
             loadedVersion,
@@ -183,12 +194,20 @@ class LocalMatch extends React.Component {
 
         if (loading) {
             content = <Message>Loading...</Message>
+        } else if (missingFileError) {
+            content = (
+                <Message>
+                    Local replay files must be loaded using the button located at the top-right.
+                </Message>
+            )
         } else if (fileError) {
             content = <Message>Error loading replay file :(</Message>
         } else if (parseError) {
-            content = <Message>
-                Invalid replay file. Only replays downloaded from pubg.sh are supported.
-            </Message>
+            content = (
+                <Message>
+                    Invalid replay file. Only replays downloaded from pubg.sh are supported.
+                </Message>
+            )
         } else if (versionError) {
             content = <Message>Unsupported replay version ${loadedVersion} :(</Message>
         } else if (telemetryError) {

--- a/src/routes/LocalMatch/index.js
+++ b/src/routes/LocalMatch/index.js
@@ -42,6 +42,19 @@ class LocalMatch extends React.Component {
         this.loadLocalReplay()
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        // React Router does not remount if route component is the same, which happens
+        // if uploading from /local-replay itself, or when navigating history between
+        // local replays.
+        if (prevProps.location !== this.props.location) {
+            // We need to to reset the component to its initial state. I think this is
+            // a legitimate use of `setState` in `componentDidUpdate`:
+            //
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState(INITIAL_STATE, this.loadLocalReplay)
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Match, Telemetry --------------------------------------------------------
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #39, work continued from #40.

- Added `version` field to saved replays:
    - Supports handling multiple versions (via `switch`), in case upgrades can be automatically handled (I'd rather be lenient if possible).
- Added distinct error messages:
    - File read error (`fileError`). Happens when file was removed/renamed, permission error, etc.
    - Parse error (`parseError`). This one hints about only pubg.sh replays being supported.
    - Version error (`versionError`)
- Added error when `file` is missing from history state:
    - Can happen if visiting the `/local-replay` route directly.
    - Initial idea was to just redirect to home, but I think it's better to show a message telling the user what happened.
    - Hints that file must be uploaded using the top-right upload button.
- Handles local replay route not remounting:
    - Now that button is in the header, it can be uploaded from the `/local-replay` route itself.
    - Since React Router won't remount if route component is the same, it must be handled in `componentDidUpdate`.
    - It also handles navigating through history now that `/local-replay` history entries can be next to each other.
- Only show replay files on local upload dialog (`accept` attribute on file input):
    - I decided to change extension to `.pubgsh.json` which is still `.json` but filters out regular JSON files when uploading.
    - It can still upload any other file (at least on Windows, selecting _"All files (\*.*)"_ on upload dialog).
    - Filename is `pubgsh-BLAHBLAH.pubgsh.json` which might be redundant (two `pubgsh` in there). I left the prepended `pubgsh` because it groups replays together when sorting by filename, but I can see a point on removing it now that it's included in the extension. I'd rather let you decide on this one.

Now that file extensions are filtered and there's a specific parse error message, I don't think it's worth detecting native PUBG replays (especially considering they're not a single file, but a folder with many files, and is normally not reachable to users).

I think the feature is pretty well rounded right now. Let me know if it needs any more work.