### PR TITLE
Check for Red/Blue Zone Deaths

### DIFF
--- a/src/models/Telemetry.parser.js
+++ b/src/models/Telemetry.parser.js
@@ -50,7 +50,8 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
 
     const getKilledBy = data => {
         const { damageTypeCategory, victim, killer } = data
-        const isBlueZone = damageTypeCategory === 'Damage_BlueZone' || (victim.name === killer.name && victim.isInBlueZone) // eslint-disable-line
+        const isBlueZone = damageTypeCategory === 'Damage_BlueZone' ||
+            (victim.name === killer.name && victim.isInBlueZone)
         const isRedZone = damageTypeCategory === 'Damage_Explosion_RedZone'
         let killedBy = killer.name
 

--- a/src/models/Telemetry.parser.js
+++ b/src/models/Telemetry.parser.js
@@ -48,6 +48,21 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
         setNewPlayerState(playerName, { [path]: latestPlayerStates[playerName][path] + delta })
     }
 
+    const getKilledBy = data => {
+        const { damageTypeCategory, victim, killer } = data
+        const isBlueZone = damageTypeCategory === 'Damage_BlueZone' || (victim.name === killer.name && victim.isInBlueZone) // eslint-disable-line
+        const isRedZone = damageTypeCategory === 'Damage_Explosion_RedZone'
+        let killedBy = killer.name
+
+        if (isBlueZone) {
+            killedBy = 'Playzone'
+        } else if (isRedZone) {
+            killedBy = 'Redzone'
+        }
+
+        return killedBy
+    }
+
     { // --- Step Zero: Initialize state
         const teammates = matchData.players.reduce((acc, p) => {
             const teammateNames = matchData.players
@@ -177,9 +192,11 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
                 }
 
                 if (d.victim.name === focusedPlayerName) {
+                    const killedBy = getKilledBy(d)
+
                     globalState.death = {
                         msSinceEpoch,
-                        killedBy: d.killer.name,
+                        killedBy,
                     }
                 }
 


### PR DESCRIPTION
Added a `getKilledBy()` function to check if the player dies in the blue/red zones and returns a `killedBy` value.

For bluezones it needed to cover if the final tick was from the zone or by bleeding out. I believe for redzones it only needs to look for `Damage_Explosion_RedZone` since it is an instant kill. Surprisingly hard to find a match where someone died in the redzone.

This closes #45 

![image](https://user-images.githubusercontent.com/216782/52510384-9b39b680-2bb0-11e9-8f7b-35aee3ba7ac6.png)
