### PR TITLE
Fix for null killer

### DIFF
--- a/src/models/Telemetry.parser.js
+++ b/src/models/Telemetry.parser.js
@@ -188,7 +188,7 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
             if (d._T === 'LogPlayerKill') {
                 setNewPlayerState(d.victim.name, { status: 'dead' })
 
-                if (d.killer.name && d.killer.name !== d.victim.name) {
+                if (d.killer && d.killer.name && d.killer.name !== d.victim.name) {
                     incrementPlayerStateVal(d.killer.name, 'kills', 1)
                 }
 
@@ -201,7 +201,7 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
                     }
                 }
 
-                if (d.killer.name === focusedPlayerName) {
+                if (d.killer && d.killer.name === focusedPlayerName) {
                     globalState.kills.push({
                         msSinceEpoch,
                         victimName: d.victim.name,


### PR DESCRIPTION
https://github.com/pubgsh/client/issues/52

Due to changes in V12 of APIs: https://documentation.pubg.com/en/changelog/changelog.html#v12-0-0
LogPlayerKill.Killer can be null. This PR should fix pubg.sh to account for that change in the APIs