### PR TITLE
Fix for undocumented breaking API change

### DIFF
--- a/src/models/Telemetry.js
+++ b/src/models/Telemetry.js
@@ -65,7 +65,8 @@ export default function Telemetry(state) {
     }
 
     const finalRoster = focusedPlayer => {
-        const rosters = sortBy(groupBy(state.matchEnd.characters, 'teamId'), r => minBy(r, 'ranking').ranking)
+        const characters = state.matchEnd.characters.map(c => c.character || c)
+        const rosters = sortBy(groupBy(characters, 'teamId'), r => minBy(r, 'ranking').ranking)
         const focusedRosterIdx = rosters.findIndex(r => r.some(c => c.name === focusedPlayer))
         const [focusedRoster] = rosters.splice(focusedRosterIdx, 1)
         const sortedRosters = [focusedRoster, ...rosters]


### PR DESCRIPTION
LogMatchEnd.characters is no longer a list of Character objects, but a list of objects that contain some weapon info and the Character object as a property