### PR TITLE
Parse assists from match data - Fix ellipses for long names in match datapoints

### DIFF
--- a/src/components/MatchPlayer/Roster/index.js
+++ b/src/components/MatchPlayer/Roster/index.js
@@ -35,7 +35,7 @@ const PlayerItem = styled.li`
     overflow: hidden;
     cursor: pointer;
     display: grid;
-    grid-template-columns: 1fr 15px 25px;
+    grid-template-columns: 75px .25fr .25fr .5fr;
     grid-column-gap: 5px;
 
     i {
@@ -87,6 +87,7 @@ const Roster = ({ match, telemetry, marks, rosters }) => {
                                         <PlayerName>{p.name}</PlayerName>
                                     </Tooltip>
                                     <PlayerDatapoint>{p.kills}</PlayerDatapoint>
+                                    <PlayerDatapoint>{p.assists}</PlayerDatapoint>
                                     <PlayerDatapoint>{Math.round(p.damageDealt)}</PlayerDatapoint>
                                 </PlayerItem>
                             )

--- a/src/components/MatchPlayer/index.js
+++ b/src/components/MatchPlayer/index.js
@@ -230,7 +230,7 @@ class MatchPlayer extends React.Component {
                                 />
                             </MapContainer>
                             <RosterContainer mapSize={mapSize}>
-                                <RosterHeader>Name / Kills / Damage</RosterHeader>
+                                <RosterHeader>Name / Kills / Assists / Damage</RosterHeader>
                                 <Roster
                                     match={match}
                                     telemetry={currentTelemetry}

--- a/src/models/Telemetry.parser.js
+++ b/src/models/Telemetry.parser.js
@@ -43,6 +43,7 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
                 teammates: [],
                 health: 100,
                 kills: 0,
+                assists: 0,
                 damageDealt: 0,
                 items: [],
             }
@@ -94,6 +95,7 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
                 teammates: teammates[p.name],
                 health: 100,
                 kills: 0,
+                assists: 0,
                 damageDealt: 0,
                 items: [],
             }
@@ -208,6 +210,10 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
 
                 if (d && d.killer && d.killer.name && d.killer.name !== d.victim.name) {
                     incrementPlayerStateVal(d.killer.name, 'kills', 1)
+                }
+
+                if (d && d.assistant && d.assistant.name && d.assistant.name !== d.killer.name) {
+                    incrementPlayerStateVal(d.assistant.name, 'assists', 1)
                 }
 
                 if (d && d.victim.name === focusedPlayerName) {


### PR DESCRIPTION
![Screen Shot 2020-11-03 at 3 55 13 PM](https://user-images.githubusercontent.com/2301918/98050389-d3564380-1dee-11eb-9c60-5cfb0d906ae0.png)
