### PR TITLE
Add support for Assists with event LogPlayerKillV2

### DIFF
--- a/src/models/Telemetry.parser.js
+++ b/src/models/Telemetry.parser.js
@@ -212,8 +212,11 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
                     incrementPlayerStateVal(d.killer.name, 'kills', 1)
                 }
 
-                if (d && d.assistant && d.assistant.name && d.assistant.name !== d.killer.name) {
-                    incrementPlayerStateVal(d.assistant.name, 'assists', 1)
+                if (d && d.assists_AccountId && d.assists_AccountId.length > 0) {
+                    d.assists_AccountId.forEach(assistId => {
+                        const players = matchData.players.filter(p => p.id === assistId)
+                        players.forEach(p => incrementPlayerStateVal(p.name, 'assists', 1))
+                    })
                 }
 
                 if (d && d.victim.name === focusedPlayerName) {


### PR DESCRIPTION
Hey, with #80, I noticed also that the Telemetry event switched from the convenient `assistant` to `assists_AccountId`.

This PR attempts to fix Assists parsing in a crude way.

During my tests initial parsing performance wasn't too impacted, but perhaps there is a better to do that?