### PR TITLE
Non-player entity attack fix

### DIFF
--- a/src/models/Telemetry.parser.js
+++ b/src/models/Telemetry.parser.js
@@ -237,6 +237,9 @@ export default function parseTelemetry(matchData, telemetry, focusedPlayerName) 
             }
 
             if (d._T === 'LogPlayerTakeDamage') {
+                // Handle the case where a player attacks other entities than players (e.g. bears, bird cages, etc.)
+                if (d.victim.type.indexOf('user') === -1) return
+
                 incrementPlayerStateVal(d.victim.name, 'health', -d.damage)
                 setNewPlayerLocation(d.victim.name, { x: d.victim.location.x, y: d.victim.location.y })
 


### PR DESCRIPTION
Fixed a case where the player attacks non-player entities (such as bears or bird cages).

This should fix #92, I am not entirely sure, though. If there is any particular match that does not work, please let me know and provide a link, I will try to fix it.